### PR TITLE
Use Date.prototype.toLocaleString() to format date

### DIFF
--- a/static/js/admin/pads.js
+++ b/static/js/admin/pads.js
@@ -35,16 +35,10 @@ exports.documentReady = async (hookName, context) => {
   const isInt = (input) => typeof input === 'number' && input % 1 === 0;
 
   const formatDate = (longtime) => {
-    if (longtime == null || !isInt(longtime)) return '';
-    const date = new Date(longtime);
-    const month = date.getMonth() + 1;
-    return (date.getFullYear() +
-            '-' + fillZeros(month) +
-            '-' + fillZeros(date.getDate()) +
-            ' ' +
-            fillZeros(date.getHours()) +
-            ':' + fillZeros(date.getMinutes()) +
-            ':' + fillZeros(date.getSeconds()));
+    return (new Date(longtime)).toLocaleString(undefined, {
+      dateStyle: 'short',
+      timeStyle: 'long',
+    });
   };
 
   const fillZeros = (x) => isInt(x) ? (x < 10 ? '0' + x : x) : '';


### PR DESCRIPTION
This formats the date according to the user's chosen locale.

Does this work for you @MShultz?

To try it out:
```shell
$ cd /path/to/etherpad-lite
$ npm i rhansen/ep_adminpads2#formatdate
```