### PR TITLE
en and hu translation updates

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -15,7 +15,7 @@
   "ep_adminpads2_confirm": "Do you really want to delete the pad {{padID}}?",
   "ep_adminpads2_unknown-status": "Unknown status",
   "ep_adminpads2_unknown-error": "Unknown error",
-  "ep_adminpads2_search-done": "Search done",
+  "ep_adminpads2_search-done": "Search complete",
   "ep_adminpads2_no-results": "No results",
 
   "ep_adminpads2_manage-pads": "Manage pads"

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -14,6 +14,8 @@
 
   "ep_adminpads2_confirm": "Biztosan törölni szeretné a(z) {{padID}} jegyzetfüzetet?",
   "ep_adminpads2_unknown-status": "Ismeretlen állapot",
+  "ep_adminpads2_unknown-error": "Ismeretlen hiba",
+  "ep_adminpads2_search-done": "Keresés befejezve",
   "ep_adminpads2_no-results": "Nincs találat",
 
   "ep_adminpads2_manage-pads": "Jegyzetfüzetek kezelése"


### PR DESCRIPTION
"Search complete" sounds more correct
https://www.microsoft.com/en-us/language/Search?&searchTerm=Search%20complete&langID=382&Source=true&productid=undefined

If there are new strings in `en.json`, can you also please add them to the `hu.json` file (even if they are in English)?

If you could also please ping us if there are new translations it would be appreciated.

Thank you